### PR TITLE
main: updating the version properly pin patch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Creates DC/OS Public Agent intances
 ```hcl
 module "pubagts" {
   source = "dcos-terraform/instances/gcp"
-  version = "~> 0.0"
+  version = "~> 0.0.0"
 
   num_instance                   = "${var.instances_count}"
   disk_size                      = "${var.gcp_instances_disk_size}"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Creates DC/OS Public Agent intances
 ```hcl
 module "pubagts" {
   source = "dcos-terraform/instances/gcp"
-  version = "~> 0.0.0"
+  version = "~> 0.1.0"
 
   num_instance                   = "${var.instances_count}"
   disk_size                      = "${var.gcp_instances_disk_size}"

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@
  *```hcl
  * module "pubagts" {
  *   source = "dcos-terraform/instances/gcp"
- *   version = "~> 0.0.0"
+ *   version = "~> 0.1.0"
  *
  *   num_instance                   = "${var.instances_count}"
  *   disk_size                      = "${var.gcp_instances_disk_size}"
@@ -35,7 +35,7 @@ locals {
 
 module "dcos-public-agent-instances" {
   source  = "dcos-terraform/instance/gcp"
-  version = "~> 0.0.0"
+  version = "~> 0.1.0"
 
   providers = {
     google = "google"

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@
  *```hcl
  * module "pubagts" {
  *   source = "dcos-terraform/instances/gcp"
- *   version = "~> 0.0"
+ *   version = "~> 0.0.0"
  *
  *   num_instance                   = "${var.instances_count}"
  *   disk_size                      = "${var.gcp_instances_disk_size}"
@@ -35,7 +35,7 @@ locals {
 
 module "dcos-public-agent-instances" {
   source  = "dcos-terraform/instance/gcp"
-  version = "~> 0.0"
+  version = "~> 0.0.0"
 
   providers = {
     google = "google"


### PR DESCRIPTION
This updates the version behaivor to have ~> 0.1.0: any non-beta version >= 0.1.0 and < 0.2.0

https://www.terraform.io/docs/modules/usage.html#gt-1-2